### PR TITLE
Respect empty service.spec.type

### DIFF
--- a/rules/repository.go
+++ b/rules/repository.go
@@ -413,7 +413,7 @@ func (this *repositoryImplState) ingressToBackend(source support.ObjectReference
 		return nil, nil
 	}
 
-	if service.Spec.Type != v1.ServiceTypeClusterIP {
+	if service.Spec.Type != v1.ServiceTypeClusterIP && service.Spec.Type != "" {
 		usingLogger.
 			With("serviceType", service.Spec.Type).
 			Warn("Unsupported serviceType; ignoring...")


### PR DESCRIPTION
## Motivation
Currently if a service does have an empty `spec.type` it will be treated as an error.

## Changes
`<empty>` is now assumed as `ClusterIP`.
