### PR TITLE
Set upstream host correctly

### DIFF
--- a/proxy/hints.go
+++ b/proxy/hints.go
@@ -19,6 +19,7 @@ func UpstreamHintsInterceptor(ctx *context.Context) (proceed bool, err error) {
 	if u, err := ctx.Client.RequestedUrl(); err != nil {
 		return false, err
 	} else if u != nil {
+		ctx.Upstream.Request.Host = u.Host
 		h.Set("Host", u.Host)
 		h.Set("X-Forwarded-Host", u.Host)
 		h.Set("X-Forwarded-Proto", u.Scheme)


### PR DESCRIPTION
## Motivation
The `Host` header is not set correctly for the upstream host. Servers that rely on this header instead of `X-Forwarded-Host` might not work.

## Changes
Set the `Host` header correctly.
